### PR TITLE
Fix merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Terminal-copilot can be called with optional command line arguments:
 - `-hist`, `--history`: Enables the inclusion of terminal history in the prompt sent to the OpenAI API. May potentially send sensitive information to OpenAI and increase the number of tokens used.
 - `-j`, `--json`: Output data as JSON instead of using an interactive prompt.
 - `-c`, `--count`: The number of commands to output when JSON output is specified.
+- `-c`, `--count`: The number of commands to output when JSON output is specified.
+- `-m`, `--model`: The model to use. Defaults to gpt-3.5-turbo.
+- `-ns`, `--no-stream`: Disable streaming the command into the terminal (by default, streaming is enabled).
 
 ### Requirements
 Python 3.7+

--- a/copilot/main.py
+++ b/copilot/main.py
@@ -84,7 +84,6 @@ The user has several environment variables set, some of which are:
 The user has the following aliases set:
 {subprocess.run(["alias"], capture_output=True, shell=True).stdout.decode("utf-8")}
 """
-    prompt += """
 
     conversation = build_conversation(context)
 


### PR DESCRIPTION
This commit removes a duplicate statements that must have got onto the main during a merge.
Furthermore, it adds to command line arguments to the documentation that where missing.